### PR TITLE
Minor formatting cleanup, no functional change

### DIFF
--- a/src/point3d/sortinghopper/BreakListener.java
+++ b/src/point3d/sortinghopper/BreakListener.java
@@ -12,7 +12,7 @@ import org.bukkit.inventory.ItemStack;
  * with "customized" hopper. Does not play well with block break protection
  * plugins.
  */
-public final class BreakListener implements Listener{
+public final class BreakListener implements Listener {
 
 	private final SortingHopper plugin;
 
@@ -28,25 +28,25 @@ public final class BreakListener implements Listener{
 
 	/**
 	 * Event handler for block breaking
-	 * 
+	 *
 	 * @param event the Block Break Event
 	 */
 	@EventHandler
-	public void onBlockBreak(BlockBreakEvent event){
-		if(event.getPlayer().getGameMode() == GameMode.CREATIVE){
+	public void onBlockBreak(BlockBreakEvent event) {
+		if (event.getPlayer().getGameMode() == GameMode.CREATIVE) {
 			return;
 		}
-		if (event.getBlock().getType() == Material.HOPPER){
+		if (event.getBlock().getType() == Material.HOPPER) {
 			Hopper hopper = (Hopper)event.getBlock().getState();
 
-			if(plugin.checkNames(hopper.getInventory().getName())){
+			if (plugin.checkNames(hopper.getInventory().getName())) {
 				ItemStack drop = plugin.getItem();
-				
-				//Looks hacky
+
+				// Looks hacky
 				event.setCancelled(true);
 				event.getBlock().setType(Material.AIR);
 				event.getBlock().getWorld().dropItemNaturally(event.getBlock().getLocation(), drop);
 			}
-		}  
+		}
 	}
 }

--- a/src/point3d/sortinghopper/HopperListener.java
+++ b/src/point3d/sortinghopper/HopperListener.java
@@ -25,7 +25,7 @@ public final class HopperListener implements Listener {
 		}
 		this.plugin = plugin;
 	}
-	
+
 	/**
 	 * Inventory movement event, triggered by hopper seek.
 	 *
@@ -37,21 +37,21 @@ public final class HopperListener implements Listener {
 		Inventory dest = event.getDestination();
 		Inventory source = event.getSource();
 
-		//Prevent items from being pulled out by other hopper
-		if(plugin.getConfig().getBoolean("preventitempull")){
-			if(plugin.checkNames(source.getName()) && initiator != source){ 
+		// Prevent items from being pulled out by other hopper
+		if (plugin.getConfig().getBoolean("preventitempull")) {
+			if (plugin.checkNames(source.getName()) && initiator != source) {
 				event.setCancelled(true);
 			}
 		}
 
-		if(plugin.checkNames(initiator.getName())){
-			if(!initiator.contains(event.getItem().getType())) {
+		if (plugin.checkNames(initiator.getName())) {
+			if (!initiator.contains(event.getItem().getType())) {
 				event.setCancelled(true);
 
-				//Try to move items in other slots
-				if(dest != initiator) {
-					for(int slot = 1; slot < initiator.getSize(); slot++) {
-						if( this.MoveItem(initiator, slot, dest) ){
+				// Try to move items in other slots
+				if (dest != initiator) {
+					for (int slot = 1; slot < initiator.getSize(); slot++) {
+						if ( this.MoveItem(initiator, slot, dest) ) {
 							break;
 						}
 					}
@@ -62,7 +62,7 @@ public final class HopperListener implements Listener {
 
 	/**
 	 * Internal method moveItem, does a move.
-	 * 
+	 *
 	 * @param initiator Inventory source
 	 * @param slot Inventory slot #
 	 * @param dest Inventory destination

--- a/src/point3d/sortinghopper/PickupListener.java
+++ b/src/point3d/sortinghopper/PickupListener.java
@@ -29,7 +29,7 @@ public class PickupListener implements Listener {
 	 */
 	@EventHandler
 	public void onInventoryPickupEvent(InventoryPickupItemEvent event) {
-		if(plugin.checkNames(event.getInventory().getName())) {
+		if (plugin.checkNames(event.getInventory().getName())) {
 			event.setCancelled(true);
 		}
 	}

--- a/src/point3d/sortinghopper/SortingHopper.java
+++ b/src/point3d/sortinghopper/SortingHopper.java
@@ -18,7 +18,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class SortingHopper extends JavaPlugin {
 
 	private final List<String> names = null;
-	
+
 	/**
 	 * Sets up listeners for the SortingHopper
 	 */
@@ -27,37 +27,37 @@ public class SortingHopper extends JavaPlugin {
 		PluginManager pm = getServer().getPluginManager();
 		this.saveDefaultConfig();
 
-		names = this.getConfig().getStringList("names"); 
-		 
+		names = this.getConfig().getStringList("names");
+
 		final HopperListener hopperListener = new HopperListener(this);
 		pm.registerEvents(hopperListener, this);
 
 		if (getConfig().getBoolean("replacedrops")) {
 			final BreakListener breakListener = new BreakListener(this);
-			pm.registerEvents(breakListener, this); 
+			pm.registerEvents(breakListener, this);
 		}
 		if (getConfig().getBoolean("preventitempickup")) {
 			final PickupListener pickupListener = new PickupListener(this);
 			pm.registerEvents(pickupListener, this);
-		}                
+		}
 		if (getConfig().getBoolean("crafting.enabled")) {
 			addRecipe(getItem());
-		}               
+		}
 		getLogger().info("[SortingHopper] started!");
 	}
 
 	/**
 	 * Check the given string against configured names
-	 * 
+	 *
 	 * @param name The name string to test
 	 */
-	public boolean checkNames(String name){
+	public boolean checkNames(String name) {
 		return names.contains(name);
 	}
 
 	/**
 	 * Return an ItemStack with a custom display name
-	 * 
+	 *
 	 * @return an ItemStack with custom meta
 	 */
 	public ItemStack getItem() {
@@ -91,12 +91,12 @@ public class SortingHopper extends JavaPlugin {
 			getServer().addRecipe(recipe);
 		} else {
 			ShapelessRecipe recipe = new ShapelessRecipe(item);
-			
+
 			List<String> l = getConfig().getStringList("crafting.recipe");
 			for (String s : l) {
 				recipe.addIngredient(Material.matchMaterial(s));
 			}
-			
+
 			getServer().addRecipe(recipe);
 		}
 	}


### PR DESCRIPTION
Minor whitespace cleanup:
- Added space between ')' and '{' characters.
- Ensured that all leading whitespace are tabs (aligns to 4 spaces per tab)
- Removed any trailing whitespace.
- Commented-out code has '//' immediately (no whitespace) followed by the code, while comments have a space after '//'.
- Added space between keywords ('if', 'while', 'for', 'switch') and opening parenthesis.
